### PR TITLE
Update tracking

### DIFF
--- a/docker/ckan/files/scripts/entrypoint.sh
+++ b/docker/ckan/files/scripts/entrypoint.sh
@@ -39,6 +39,10 @@ ckan db upgrade -p announcements
 # Rebuild search index
 ckan search-index rebuild
 
+# Update tracking
+LAST_MONTH=$(date -d '60 days ago' +'%Y-%m-%d')
+ckan tracking update $LAST_MONTH
+
 # Datapusher+ requires a valid API token to operate
 echo "Creating a valid API token for Datapusher+"
 DATAPUSHER_TOKEN=$(ckan user token add default datapusher_multi expires_in=365 unit=86400 | tail -n 1 | tr -d '\t')

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -34,8 +34,8 @@ pip install -e git+https://github.com/okfn/datapusher-plus.git@okfn_tmp#egg=data
 pip install -r https://raw.githubusercontent.com/okfn/datapusher-plus/okfn_tmp/requirements.txt
 
 echo "Installing API-tracking extension"
-pip install git+https://github.com/NorwegianRefugeeCouncil/ckanext-api-tracking.git@0.4.3#egg=ckanext-api-tracking
-pip install -r https://raw.githubusercontent.com/NorwegianRefugeeCouncil/ckanext-api-tracking/refs/tags/0.4.3/requirements.txt
+pip install git+https://github.com/NorwegianRefugeeCouncil/ckanext-api-tracking.git@0.4.4#egg=ckanext-api-tracking
+pip install -r https://raw.githubusercontent.com/NorwegianRefugeeCouncil/ckanext-api-tracking/refs/tags/0.4.4/requirements.txt
 
 echo "Installing Apache Superset extension"
 pip install git+https://github.com/unckan/ckanext-superset.git@0.1.9#egg=ckanext-superset


### PR DESCRIPTION
La URL es https://datosabiertos.unc.edu.ar/tracking-dashboard/latest-api-token-usage
Esto es la extensio api-tracking
Esta extension usa una base de datos interna que se actualiza con un comando de CKAN

```
# Update tracking
LAST_MONTH=$(date -d '60 days ago' +'%Y-%m-%d')
ckan tracking update $LAST_MONTH
```

Ponerlo despues de `ckan search-index rebuild` en el entrypoint de **ckan-env**
No creo que esto resuelva el error pero ya que estamos en el tema agregar esto en un PR a ckan-env

 
![image](https://github.com/user-attachments/assets/fd829a43-ccac-45f0-9b82-ffcedd08b0d5)
