### PR TITLE
Add install selfinfo

### DIFF
--- a/ckanext-unckan/test.ini
+++ b/ckanext-unckan/test.ini
@@ -8,7 +8,7 @@ use = config:../../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery
+ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
 
 # Logging configuration
 [loggers]

--- a/ckanext-unckan/test.ini
+++ b/ckanext-unckan/test.ini
@@ -13,6 +13,7 @@ ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking
 # Config selfinfo
 ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions
 ckan.selfinfo.ckan_repos = ckanext-selfinfo
+ckan.selfinfo.page_url = /ckan-admin/selfinfo
 
 # Logging configuration
 [loggers]

--- a/ckanext-unckan/test.ini
+++ b/ckanext-unckan/test.ini
@@ -8,7 +8,7 @@ use = config:../../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
+ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo selftools
 
 # Config selfinfo
 ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions

--- a/ckanext-unckan/test.ini
+++ b/ckanext-unckan/test.ini
@@ -10,6 +10,10 @@ use = config:../../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
 
+# Config selfinfo
+ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions
+ckan.selfinfo.ckan_repos = ckanext-selfinfo
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy

--- a/ckanext-unckan/test.ini
+++ b/ckanext-unckan/test.ini
@@ -8,7 +8,7 @@ use = config:../../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo selftools
+ckan.plugins = push_errors unckan pdf_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
 
 # Config selfinfo
 ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions

--- a/docker/ckan/files/ckan.ini
+++ b/docker/ckan/files/ckan.ini
@@ -140,7 +140,7 @@ ckan.cors.origin_allow_all = false
 ckan.cors.origin_whitelist =
 
 ## Plugins Settings ############################################################
-ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery selftools selfinfo
+ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
 ckan.resource_proxy.timeout = 5
 
 ## Front-End Settings ##########################################################
@@ -262,12 +262,6 @@ ckan.selfinfo.partitions = /
 ckan.selfinfo.errors_limit = 40
 ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions
 ckan.selfinfo.ckan_repos = ckanext-selfinfo ckanext-unckan
-
-## Selftools settings ##########################################################
-ckan.selftools.operations_pwd = ${CKAN_SELFTOOLS_OPERATIONS_PWD}
-ckan.selftools.categories = solr db redis config
-ckan.selftools.operations_limit = 100
-ckan.selftools.model_fields_blacklist = User.email Package.name
 
 ## Datapusher+ #################################################################
 ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv ssv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet

--- a/docker/ckan/files/ckan.ini
+++ b/docker/ckan/files/ckan.ini
@@ -280,7 +280,7 @@ keys = root, ckan, ckanext, werkzeug
 
 # ensure adding our custom handlers
 [handlers]
-keys = console, selfinfoErrorHanlder
+keys = console, selfinfoErrorHandler
 
 [formatters]
 keys = generic
@@ -297,13 +297,13 @@ propagate = 0
 
 [logger_ckan]
 level = ERROR
-handlers = console, selfinfoErrorHanlder
+handlers = console, selfinfoErrorHandler
 qualname = ckan
 propagate = 0
 
 [logger_ckanext]
 level = ERROR
-handlers = console, selfinfoErrorHanlder
+handlers = console, selfinfoErrorHandler
 qualname = ckanext
 propagate = 0
 
@@ -313,7 +313,7 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
-[handler_selfinfoErrorHanlder]
+[handler_selfinfoErrorHandler]
 class = ckanext.selfinfo.handlers.SelfinfoErrorHandler
 level = ERROR
 formatter = generic

--- a/docker/ckan/files/ckan.ini
+++ b/docker/ckan/files/ckan.ini
@@ -264,7 +264,7 @@ ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions
 ckan.selfinfo.ckan_repos = ckanext-selfinfo ckanext-unckan
 
 ## Selftools settings ##########################################################
-ckan.selftools.operations_pwd = supersegura123
+ckan.selftools.operations_pwd = ${CKAN_SELFTOOLS_OPERATIONS_PWD}
 ckan.selftools.categories = solr db redis config
 ckan.selftools.operations_limit = 100
 ckan.selftools.model_fields_blacklist = User.email Package.name

--- a/docker/ckan/files/ckan.ini
+++ b/docker/ckan/files/ckan.ini
@@ -140,7 +140,7 @@ ckan.cors.origin_allow_all = false
 ckan.cors.origin_whitelist =
 
 ## Plugins Settings ############################################################
-ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
+ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery selftools selfinfo
 ckan.resource_proxy.timeout = 5
 
 ## Front-End Settings ##########################################################
@@ -256,6 +256,19 @@ ckan.datastore.read_url = <this-will-be-replaced-with-secret>
 # scheming.dataset_schemas=ckanext.uni.schemas:uni.yaml
 # scheming.presets=ckanext.scheming:presets.json
 
+## Self-info settings ##########################################################
+ckan.selfinfo.page_url = /ckan-admin/selfinfo
+ckan.selfinfo.partitions = /
+ckan.selfinfo.errors_limit = 40
+ckan.selfinfo.ckan_repos_path = /app/unckan/src_extensions
+ckan.selfinfo.ckan_repos = ckanext-selfinfo ckanext-unckan
+
+## Selftools settings ##########################################################
+ckan.selftools.operations_pwd = supersegura123
+ckan.selftools.categories = solr db redis config
+ckan.selftools.operations_limit = 100
+ckan.selftools.model_fields_blacklist = User.email Package.name
+
 ## Datapusher+ #################################################################
 ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv ssv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet
 # According the QSV doc, qsvp is optimized to use with Datapusher+
@@ -267,7 +280,7 @@ keys = root, ckan, ckanext, werkzeug
 
 # ensure adding our custom handlers
 [handlers]
-keys = console
+keys = console, selfinfoErrorHanlder
 
 [formatters]
 keys = generic
@@ -284,13 +297,13 @@ propagate = 0
 
 [logger_ckan]
 level = ERROR
-handlers = console
+handlers = console, selfinfoErrorHanlder
 qualname = ckan
 propagate = 0
 
 [logger_ckanext]
 level = ERROR
-handlers = console
+handlers = console, selfinfoErrorHanlder
 qualname = ckanext
 propagate = 0
 
@@ -298,6 +311,11 @@ propagate = 0
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
+formatter = generic
+
+[handler_selfinfoErrorHanlder]
+class = ckanext.selfinfo.handlers.SelfinfoErrorHandler
+level = ERROR
 formatter = generic
 
 [formatter_generic]

--- a/docker/ckan/files/ckan.ini
+++ b/docker/ckan/files/ckan.ini
@@ -140,7 +140,7 @@ ckan.cors.origin_allow_all = false
 ckan.cors.origin_whitelist =
 
 ## Plugins Settings ############################################################
-ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery
+ckan.plugins = push_errors unckan image_view pdf_view datastore datatables_view datapusher_plus tracking api_tracking superset announcements dbquery selfinfo
 ckan.resource_proxy.timeout = 5
 
 ## Front-End Settings ##########################################################

--- a/docker/ckan/files/env/base.env
+++ b/docker/ckan/files/env/base.env
@@ -45,3 +45,6 @@ SUPERSER_PROXY_PASS=PASS
 
 # Push-errors extension settings
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/TP59XXX/B04XXX/rEp2xxxx
+
+# Selfinfo settings
+CKAN_SELFTOOLS_OPERATIONS_PWD=MYIiw9EsM5

--- a/docker/ckan/files/env/base.env
+++ b/docker/ckan/files/env/base.env
@@ -45,6 +45,3 @@ SUPERSER_PROXY_PASS=PASS
 
 # Push-errors extension settings
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/TP59XXX/B04XXX/rEp2xxxx
-
-# Selfinfo settings
-CKAN_SELFTOOLS_OPERATIONS_PWD=MYIiw9EsM5

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,6 +54,6 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -q -e git+https://github.com/germankay/ckanext-selfinfo.git@v1.0.0#egg=ckanext-selfinfo
+pip install -q -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.15#egg=ckanext-selfinfo
 
 echo "CKAN extensions installed"

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -53,4 +53,7 @@ echo "Installing DBQuery extension"
 pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckanext-dbquery
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
+echo "Installing Ckanext Selfinfo extension"
+pip install -e git+https://github.com/germankay/ckanext-selfinfo.git@master#egg=ckanext-selfinfo
+
 echo "CKAN extensions installed"

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,6 +54,6 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -q -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.15#egg=ckanext-selfinfo
+pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.15#egg=ckanext-selfinfo
 
 echo "CKAN extensions installed"

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,6 +54,6 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -q -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.6#egg=ckanext-selfinfo
+pip install -q -e git+https://github.com/germankay/ckanext-selfinfo.git@v1.0.0#egg=ckanext-selfinfo
 
 echo "CKAN extensions installed"

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,6 +54,6 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.15#egg=ckanext-selfinfo
+pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
 
 echo "CKAN extensions installed"

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,6 +54,6 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.0#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -e git+https://github.com/germankay/ckanext-selfinfo.git@master#egg=ckanext-selfinfo
+pip install -q -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.1.6#egg=ckanext-selfinfo
 
 echo "CKAN extensions installed"


### PR DESCRIPTION
related #64 

Documentacion https://datashades.github.io/ckanext-selfinfo/config_settings/

por el momento par auqe ande hay que ingresar directamente a /ckan-admin/selfinfo. no logre encontrar o no entendi, en la documentacion como configurar  par aque aparezca una estaña en el admin

![image](https://github.com/user-attachments/assets/cd1df914-6e09-404a-894b-70dd9923e574)