### PR TITLE
Release 0.5.1

### DIFF
--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:12-slim
 
 # Args
 ARG TZ

--- a/docker/ckan/files/env/base.env
+++ b/docker/ckan/files/env/base.env
@@ -1,7 +1,7 @@
 # Do not change this file for your local env
 # Use local.env to set your local env variables
 
-CKAN_UNI_VERSION=0.5.0
+CKAN_UNI_VERSION=0.5.1
 CKAN_GIT_URL=https://github.com/ckan/ckan.git
 CKAN_GIT_BRANCH=ckan-2.11.3
 

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -56,10 +56,6 @@ pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tag
 echo "Installing Ckanext Selfinfo extension"
 pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
 
-echo "Installing Ckanext Selfinfo extension"
-pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
-pip install pip
-
 echo "Installing citeproc extension"
 pip install -e git+https://github.com/unckan/ckanext-citeproc.git@v1.0.1#egg=ckanext-citeproc
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-citeproc/refs/tags/v1.0.1/requirements.txt

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -34,20 +34,20 @@ pip install -e git+https://github.com/okfn/datapusher-plus.git@okfn_tmp#egg=data
 pip install -r https://raw.githubusercontent.com/okfn/datapusher-plus/okfn_tmp/requirements.txt
 
 echo "Installing API-tracking extension"
-pip install -e git+https://github.com/NorwegianRefugeeCouncil/ckanext-api-tracking.git@0.5.1#egg=ckanext-api-tracking
-pip install -r https://raw.githubusercontent.com/NorwegianRefugeeCouncil/ckanext-api-tracking/refs/tags/0.5.1/requirements.txt
+pip install -e git+https://github.com/NorwegianRefugeeCouncil/ckanext-api-tracking.git@0.5.2#egg=ckanext-api-tracking
+pip install -r https://raw.githubusercontent.com/NorwegianRefugeeCouncil/ckanext-api-tracking/refs/tags/0.5.2/requirements.txt
 
 echo "Installing Apache Superset extension"
-pip install git+https://github.com/unckan/ckanext-superset.git@0.1.9#egg=ckanext-superset
-pip install -r https://raw.githubusercontent.com/unckan/ckanext-superset/refs/tags/0.1.9/requirements.txt
+pip install git+https://github.com/unckan/ckanext-superset.git@0.2.0#egg=ckanext-superset
+pip install -r https://raw.githubusercontent.com/unckan/ckanext-superset/refs/tags/0.2.0/requirements.txt
 
 echo "Installing Announcements extension"
-pip install git+https://github.com/okfn/ckanext-announcements.git@0.1.4#egg=ckanext-announcements
-pip install -r https://raw.githubusercontent.com/okfn/ckanext-announcements/0.1.4/requirements.txt
+pip install git+https://github.com/okfn/ckanext-announcements.git@0.1.6#egg=ckanext-announcements
+pip install -r https://raw.githubusercontent.com/okfn/ckanext-announcements/0.1.6/requirements.txt
 
 echo "Installing Push Errors extension"
-pip install git+https://github.com/unckan/ckanext-push-errors.git@0.1.5#egg=ckanext-push-errors
-pip install -r https://raw.githubusercontent.com/unckan/ckanext-push-errors/refs/tags/0.1.5/requirements.txt
+pip install git+https://github.com/unckan/ckanext-push-errors.git@0.1.6#egg=ckanext-push-errors
+pip install -r https://raw.githubusercontent.com/unckan/ckanext-push-errors/refs/tags/0.1.6/requirements.txt
 
 echo "Installing DBQuery extension"
 pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.2#egg=ckanext-dbquery

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,7 +54,7 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.3#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.3/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
+pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.1#egg=ckanext-selfinfo
 
 echo "Installing citeproc extension"
 pip install -e git+https://github.com/unckan/ckanext-citeproc.git@v1.0.1#egg=ckanext-citeproc

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -50,8 +50,8 @@ pip install git+https://github.com/unckan/ckanext-push-errors.git@0.1.5#egg=ckan
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-push-errors/refs/tags/0.1.5/requirements.txt
 
 echo "Installing DBQuery extension"
-pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.1#egg=ckanext-dbquery
-pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.1/requirements.txt
+pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.2#egg=ckanext-dbquery
+pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.2/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
 pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -50,8 +50,8 @@ pip install git+https://github.com/unckan/ckanext-push-errors.git@0.1.6#egg=ckan
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-push-errors/refs/tags/0.1.6/requirements.txt
 
 echo "Installing DBQuery extension"
-pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.2#egg=ckanext-dbquery
-pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.2/requirements.txt
+pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.3#egg=ckanext-dbquery
+pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.3/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
 pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -55,6 +55,7 @@ pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tag
 
 echo "Installing Ckanext Selfinfo extension"
 pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
+pip install pip
 
 echo "Installing citeproc extension"
 pip install -e git+https://github.com/unckan/ckanext-citeproc.git@v1.0.1#egg=ckanext-citeproc

--- a/docker/ckan/files/scripts/install-extensions.sh
+++ b/docker/ckan/files/scripts/install-extensions.sh
@@ -54,7 +54,7 @@ pip install -e git+https://github.com/unckan/ckanext-dbquery.git@0.2.3#egg=ckane
 pip install -r https://raw.githubusercontent.com/unckan/ckanext-dbquery/refs/tags/0.2.3/requirements.txt
 
 echo "Installing Ckanext Selfinfo extension"
-pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.1#egg=ckanext-selfinfo
+pip install -e git+https://github.com/DataShades/ckanext-selfinfo.git@v1.2.0#egg=ckanext-selfinfo
 
 echo "Installing citeproc extension"
 pip install -e git+https://github.com/unckan/ckanext-citeproc.git@v1.0.1#egg=ckanext-citeproc


### PR DESCRIPTION
fixes #70 

New release 0.5.1

- Update tags 0.5.0 >> 0.5.1
- update DBquery ckanext-dbquery.git@0.2.2
- delete duplicate install-extenssions self-info solo queda 1.2.0
- Update Push Errors 0.1.5 >> 0.1.6
- update Announcements 0.1.4  >>  0.1.6
- update superset 0.1.9 >> 0.2.0
- update API-tracking 0.5.1 >>> 0.5.2
- 