### PR TITLE
Update CKAN branch to version 2.11.4 in base.env

### DIFF
--- a/.github/workflows/test-unckan-extension.yml
+++ b/.github/workflows/test-unckan-extension.yml
@@ -13,7 +13,7 @@ jobs:
     services:
 
       solr:
-        image: ckan/ckan-solr:2.10-solr9
+        image: ckan/ckan-solr:2.11-solr9
 
       postgres:
         image: ckan/ckan-postgres-dev:2.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
  - Add trabslations (ES) [#53](https://github.com/unckan/ckanext-superset/pull/53)
  - Allow automatic sync resources [#52](https://github.com/unckan/ckanext-superset/pull/52)
  - Add filters to the charts list [#50](https://github.com/unckan/ckanext-superset/pull/50)
-
+ - Remove SelfInfo extension [#83](https://github.com/unckan/ckan-env/pull/83)
+ - Move from Datapusher+ to XLoader
+ - Dev env notes using Hetzer added
+ - Moving from Debian 12 to Debian 13
 
 # Release 0.5.2
 2025-09-17

--- a/deploy/hetzner/docker-compose.prod.yml
+++ b/deploy/hetzner/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
 
   solr_uni:
     container_name: solr_uni
-    image: ckan/ckan-solr:2.10
+    image: ckan/ckan-solr:2.11-solr9
     restart: unless-stopped
     environment:
       # Limita el heap de la JVM de Solr. Default ~1-2 GB. En Hetzner 8GB

--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -59,7 +59,7 @@ USER ckan
 RUN uv python install 3.11
 RUN uv venv ${APP_DIR}/venv --python 3.11
 ENV PATH="${APP_DIR}/venv/bin:$PATH"
-RUN uv pip install wheel gunicorn psycopg2-binary
+RUN uv pip install "setuptools>=61,<81" wheel gunicorn psycopg2-binary
 
 # Install CKAN
 RUN ${APP_DIR}/files/scripts/install-ckan.sh

--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:13-slim
 
 # Args
 ARG TZ
@@ -10,6 +10,9 @@ ENV CKAN_INI=${APP_DIR}/ckan.ini
 
 WORKDIR ${APP_DIR}
 RUN apt update
+
+# Bring uv binary for Python and venv management
+COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
 
 # Copy files one by one to ensure Dockerfile is caching layers
 # and the change in one file does not invalidate the cache of the others
@@ -50,6 +53,13 @@ RUN useradd -m -s /bin/bash ckan
 RUN chown ckan -R ${APP_DIR}
 RUN chown ckan -R /var/log/supervisor
 USER ckan
+
+# Create venv with a pinned Python (avoid Debian default Python drift)
+# uv will download/manage Python 3.11 if not present
+RUN uv python install 3.11
+RUN uv venv ${APP_DIR}/venv --python 3.11
+ENV PATH="${APP_DIR}/venv/bin:$PATH"
+RUN uv pip install wheel gunicorn psycopg2-binary
 
 # Install CKAN
 RUN ${APP_DIR}/files/scripts/install-ckan.sh

--- a/docker/ckan/files/env/base.env
+++ b/docker/ckan/files/env/base.env
@@ -3,7 +3,7 @@
 
 CKAN_UNI_VERSION=0.6.0
 CKAN_GIT_URL=https://github.com/ckan/ckan.git
-CKAN_GIT_BRANCH=ckan-2.11.3
+CKAN_GIT_BRANCH=ckan-2.11.4
 
 # A folder for storing uploaded (and other) files in $APP_DIR
 CKAN_STORAGE_FOLDER=storage

--- a/docker/ckan/files/env/base.env
+++ b/docker/ckan/files/env/base.env
@@ -3,7 +3,7 @@
 
 CKAN_UNI_VERSION=0.6.0
 CKAN_GIT_URL=https://github.com/ckan/ckan.git
-CKAN_GIT_BRANCH=ckan-2.11.4
+CKAN_GIT_BRANCH=ckan-2.11.5
 
 # A folder for storing uploaded (and other) files in $APP_DIR
 CKAN_STORAGE_FOLDER=storage

--- a/docker/ckan/files/scripts/entrypoint.sh
+++ b/docker/ckan/files/scripts/entrypoint.sh
@@ -22,7 +22,15 @@ until psql -d $SQLALCHEMY_URL -c '\q'; do
   sleep 3
 done
 
-source ${APP_DIR}/venv/bin/activate
+# venv is already on PATH (set in Dockerfile)
+
+echo "Checking if CKAN DB is initialized"
+if ! psql -d "$SQLALCHEMY_URL" -tAc "SELECT 1 FROM information_schema.tables WHERE table_name='package'" | grep -q 1; then
+  echo "CKAN DB init"
+  ckan db init
+else
+  echo "CKAN DB already initialized, skipping db init"
+fi
 
 echo "CKAN db upgrade"
 ckan db upgrade

--- a/docker/ckan/files/scripts/entrypoint.sh
+++ b/docker/ckan/files/scripts/entrypoint.sh
@@ -22,16 +22,6 @@ until psql -d $SQLALCHEMY_URL -c '\q'; do
   sleep 3
 done
 
-# venv is already on PATH (set in Dockerfile)
-
-echo "Checking if CKAN DB is initialized"
-if ! psql -d "$SQLALCHEMY_URL" -tAc "SELECT 1 FROM information_schema.tables WHERE table_name='package'" | grep -q 1; then
-  echo "CKAN DB init"
-  ckan db init
-else
-  echo "CKAN DB already initialized, skipping db init"
-fi
-
 echo "CKAN db upgrade"
 ckan db upgrade
 

--- a/docker/ckan/files/scripts/install-ckan.sh
+++ b/docker/ckan/files/scripts/install-ckan.sh
@@ -10,6 +10,11 @@ echo "Installing CKAN $CKAN_GIT_BRANCH :: $CKAN_GIT_URL :: $(python --version)"
 python -m venv ${APP_DIR}/venv
 source ${APP_DIR}/venv/bin/activate
 pip install gunicorn yacron
+# NOTE:
+# The venv is created in the Dockerfile using uv with Python 3.11 pinned.
+# PATH is already set to use ${APP_DIR}/venv/bin
+
+uv pip install --upgrade pip setuptools wheel
 
 echo "Creating CKAN storage directory: $CKAN_STORAGE_FOLDER"
 mkdir -p ${APP_DIR}/${CKAN_STORAGE_FOLDER}
@@ -20,17 +25,17 @@ git clone -b "$CKAN_GIT_BRANCH" $CKAN_GIT_URL ckan
 cd ckan
 
 echo "Installing requirements"
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 
 # The boolean IS_DEV_ENV define if we need to install dev requirements
 if [ "$IS_DEV_ENV" = "true" ] ; then
   echo "Installing dev requirements"
-  pip install -r dev-requirements.txt
-  pip install flask-debugtoolbar
+  uv pip install -r dev-requirements.txt
+  uv pip install flask-debugtoolbar
 fi
 
 echo "Installing CKAN package"
-pip install .
+uv pip install .
 
 echo "Patch CKAN if required"
 cd ${APP_DIR}

--- a/docker/ckan/files/scripts/install-ckan.sh
+++ b/docker/ckan/files/scripts/install-ckan.sh
@@ -14,7 +14,7 @@ pip install gunicorn yacron
 # The venv is created in the Dockerfile using uv with Python 3.11 pinned.
 # PATH is already set to use ${APP_DIR}/venv/bin
 
-uv pip install --upgrade pip setuptools wheel
+uv pip install "setuptools>=61,<81" wheel
 
 echo "Creating CKAN storage directory: $CKAN_STORAGE_FOLDER"
 mkdir -p ${APP_DIR}/${CKAN_STORAGE_FOLDER}

--- a/docker/ckan/files/scripts/install-os-deps.sh
+++ b/docker/ckan/files/scripts/install-os-deps.sh
@@ -5,7 +5,9 @@ echo "Installing OS dependencies"
 # =====================================================
 # Install more dependencies
 apt update
-apt install -y gettext-base file git libmagic1 libpq-dev postgresql-client supervisor uchardet unzip vim wget
+apt install -y gettext-base file git libmagic1 libpq-dev libuchardet-dev postgresql-client \
+    supervisor uchardet unzip vim wget xmlsec1 \
+    texlive-latex-extra latexmk curl
 
 # git: to pull the CKAN source code from GitHub
 # libmagic1: for the file upload functionality in CKAN

--- a/docker/docker-compose.sample.yml
+++ b/docker/docker-compose.sample.yml
@@ -50,7 +50,7 @@ services:
 
   solr_uni:
     container_name: solr_uni
-    image: ckan/ckan-solr:2.10-solr9
+    image: ckan/ckan-solr:2.11-solr9
     ports:
       - "8014:8983"
     volumes:


### PR DESCRIPTION
fixes #79 
fixes https://github.com/unckan/ckan-env/issues/77

## Cambios incluidos

- Actualización de la imagen base Docker de `debian:12-slim` a `debian:13-slim`.
- Migración del manejo de Python y virtualenv a **uv** (Python 3.11).
- Actualización de CKAN de `2.11.3` a `2.11.4`.
- Actualización de la imagen de Solr a `ckan-solr:2.11-solr9`.
- Simplificación del entrypoint de CKAN (evita reinicializar la base de datos si ya existe).
- Mejora del flujo de instalación de dependencias Python para mayor reproducibilidad.
- Agregado de dependencias del sistema: `xmlsec1`, `texlive-latex-extra`, `latexmk`, `curl`.

<img width="708" height="710" alt="image" src="https://github.com/user-attachments/assets/c32bc7ad-4966-4607-9ee4-071c5c0d0935" />
